### PR TITLE
[STEP3] 문자열 계산기 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation project(path: ':domain')
+    implementation project(':domain')
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.2'

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -8,6 +8,24 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+ext.junit_version = "5.8.2"
+ext.assertj_version = "3.22.0"
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit_version"
+    testImplementation "org.assertj:assertj-core:$assertj_version"
+
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/domain/src/main/java/com/example/domain/MyClass.kt
+++ b/domain/src/main/java/com/example/domain/MyClass.kt
@@ -1,4 +1,0 @@
-package com.example.domain
-
-class MyClass {
-}

--- a/domain/src/main/java/edu/nextstep/camp/domain/BinaryCalculator.kt
+++ b/domain/src/main/java/edu/nextstep/camp/domain/BinaryCalculator.kt
@@ -1,0 +1,22 @@
+package com.example.domain
+
+import java.lang.IllegalArgumentException
+
+typealias Operator = (Int, Int) -> Int
+
+internal class BinaryCalculator private constructor(private val operator: Operator) {
+
+    fun calculate(operator1: Int, operator2: Int) = operator.invoke(operator1, operator2)
+
+    companion object {
+        fun searchOperator(token: String) = BinaryCalculator(operator(token))
+
+        private fun operator(token: String): Operator = when (token) {
+            "+" -> { x, y -> x + y }
+            "-" -> { x, y -> x - y }
+            "*" -> { x, y -> x * y }
+            "/" -> { x, y -> x / y }
+            else -> throw IllegalArgumentException()
+        }
+    }
+}

--- a/domain/src/main/java/edu/nextstep/camp/domain/Calculator.kt
+++ b/domain/src/main/java/edu/nextstep/camp/domain/Calculator.kt
@@ -1,0 +1,21 @@
+package com.example.domain
+
+typealias Chunks = List<String>
+
+object Calculator {
+
+    fun evaluate(expression: String?, delimiter: String): Int {
+        val chunks = splitExpression(expression, delimiter)
+        val initial = chunks.first().toInt()
+        val restChunks = chunks.drop(1)
+
+        return restChunks.chunked(2).fold(initial) {
+            acc, (token, operand) -> BinaryCalculator.searchOperator(token).calculate(acc, operand.toInt())
+        }
+    }
+
+    fun splitExpression(expression: String?, delimiter: String): Chunks {
+        require(expression.isNullOrBlank().not())
+        return expression?.trim()?.split(delimiter) ?: throw IllegalArgumentException()
+    }
+}

--- a/domain/src/test/java/edu/nextstep/camp/domain/CalculatorTest.kt
+++ b/domain/src/test/java/edu/nextstep/camp/domain/CalculatorTest.kt
@@ -1,0 +1,30 @@
+package com.example.domain
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
+
+class CalculatorTest {
+    @Test
+    fun evaluatesExpression() {
+        //given
+        val expression = "2 + 3 * 4 / 2"
+        val delimiter = " "
+        val expected = 10
+
+        //then
+        assertEquals(expected, Calculator.evaluate(expression, delimiter))
+    }
+
+    @Test
+    fun testNullInput() {
+        //given
+        val expression = ""
+        val delimiter = " "
+
+        //then
+        assertThrows<IllegalArgumentException> { Calculator.splitExpression(expression, delimiter) }
+    }
+
+}

--- a/domain/src/test/java/edu/nextstep/camp/domain/CalculatorTest.kt
+++ b/domain/src/test/java/edu/nextstep/camp/domain/CalculatorTest.kt
@@ -1,26 +1,91 @@
-package com.example.domain
+package edu.nextstep.camp.domain
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import com.example.domain.Calculator
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.lang.IllegalArgumentException
 
 class CalculatorTest {
     @Test
-    fun evaluatesExpression() {
+    fun testAdd() {
         //given
-        val expression = "2 + 3 * 4 / 2"
+        val expression = "2 + 3"
         val delimiter = " "
-        val expected = 10
+        val expected = 5
 
         //then
-        assertEquals(expected, Calculator.evaluate(expression, delimiter))
+        assertThat(Calculator.evaluate(expression, delimiter)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testSubtract() {
+        //given
+        val expression = "2 - 3"
+        val delimiter = " "
+        val expected = -1
+
+        //then
+        assertThat(Calculator.evaluate(expression, delimiter)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testMultiply() {
+        //given
+        val expression = "2 * 3"
+        val delimiter = " "
+        val expected = 6
+
+        //then
+        assertThat(Calculator.evaluate(expression, delimiter)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testDivide() {
+        //given
+        val expression = "4 / 2"
+        val delimiter = " "
+        val expected = 2
+
+        //then
+        assertThat(Calculator.evaluate(expression, delimiter)).isEqualTo(expected)
+    }
+
+    @Test
+    fun evaluatesExpression() {
+        //given
+        val expression = "1 - 2 + 3 * 4 / 2"
+        val delimiter = " "
+        val expected = 4
+
+        //then
+        assertThat(Calculator.evaluate(expression, delimiter)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testNonArithmeticOperatorInput() {
+        //given
+        val expression = "2 $ 3"
+        val delimiter = " "
+
+        //then
+        assertThrows<IllegalArgumentException> { Calculator.evaluate(expression, delimiter) }
     }
 
     @Test
     fun testNullInput() {
         //given
         val expression = ""
+        val delimiter = " "
+
+        //then
+        assertThrows<IllegalArgumentException> { Calculator.splitExpression(expression, delimiter) }
+    }
+
+    @Test
+    fun testBlankInput() {
+        //given
+        val expression = " "
         val delimiter = " "
 
         //then


### PR DESCRIPTION
* 최대한 메서드를 분리하기 위해 노력하였습니다
    * 구분자로 입력받은 문자열 분리하는 메서드
    * 연산자에 따라 계산식을 반환하는 고차함수
    * 두 정수를 받아 계산식을 실행하는 메서드

* 테스트 코드 작성 시 `assertThrows` 사용 시 다음과 같은 오류가 발생하였습니다

> cannot inline bytecode built with jvm target 1.8 into bytecode that is being built with jvm target 1.6. please specify proper '-jvm-target' option adding support for java 8 language features could solve this issue.

preferences 에서 kotlin compiler 를 확인해 보았을 때, 1.8로 잘 설정되어있었습니다.
다음 코드를 build.gradle에 추가했을 때 해결되었는데, 다음과 같은 코드를 작성해야 하는 이유가 궁금합니다!

``` kotlin
tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
    kotlinOptions {
        jvmTarget = "1.8"
    }
}
```

이번 리뷰도 잘 부탁드립니다 :)